### PR TITLE
Added new GD dependency

### DIFF
--- a/setup/packages.txt
+++ b/setup/packages.txt
@@ -28,6 +28,7 @@ mingw-w64-x86_64-gdb
 mingw-w64-x86_64-openocd
 mingw-w64-x86_64-opencl-icd
 mingw-w64-x86_64-lz4
+mingw-w64-x86_64-libgd
 ##############################
 #         ChameleonMini      #
 ##############################


### PR DESCRIPTION
Added a new dependency to compile with Waveshare ePaper support, as will be used when https://github.com/RfidResearchGroup/proxmark3/pull/2237 gets merged.
